### PR TITLE
calculateRowStyles e calculateRowStyles in SimpleTable

### DIFF
--- a/src/lib/components/composed/list/PaginatedTable.svelte
+++ b/src/lib/components/composed/list/PaginatedTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-  import SimpleTable from "$lib/components/simple/lists/SimpleTable.svelte";
+  import SimpleTable, { type CalculateRowClasses, type CalculateRowStyles } from "$lib/components/simple/lists/SimpleTable.svelte";
   import Icon from "$lib/components/simple/media/Icon.svelte";
   import Paginator from "$lib/components/simple/lists/Paginator.svelte";
   import Dropdown from "$lib/components/composed/forms/Dropdown.svelte";
@@ -8,7 +8,9 @@
   type ArrayElement<ArrayType extends readonly unknown[]> =
     ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
 
-  export type Header = ArrayElement<NonNullable<ComponentProps<SimpleTable>['headers']>>;
+  export type Header = ArrayElement<
+    NonNullable<ComponentProps<SimpleTable>["headers"]>
+  >;
 </script>
 
 <script lang="ts">
@@ -20,7 +22,7 @@
   let clazz: {
     simpleTable?: ComponentProps<SimpleTable>['class']
   } = {};
-	export { clazz as class };
+  export { clazz as class };
 
   export let headers: ComponentProps<SimpleTable>['headers'] = [],
     items: ComponentProps<SimpleTable>['items'] = [],
@@ -42,6 +44,9 @@
     searchBarPlaceholder: string = "Type something to search...",
     lang: 'it' | 'en' = 'en',
     editFilterMode: 'one-edit' | 'multi-edit' = 'one-edit'
+
+  export let calculateRowStyles: CalculateRowStyles | undefined = undefined;
+  export let calculateRowClasses: CalculateRowClasses | undefined = undefined;
 
   let searchBarInput: HTMLElement,
     searchText: string | undefined = undefined
@@ -147,6 +152,8 @@
     bind:sortDirection
     on:sort
     on:rowClick
+    {calculateRowStyles}
+    {calculateRowClasses}
   >
     <svelte:fragment slot="header" let:head>
       <slot name="header" {head} >

--- a/src/lib/components/simple/lists/SimpleTable.svelte
+++ b/src/lib/components/simple/lists/SimpleTable.svelte
@@ -17,6 +17,18 @@
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     data?: { [key: string]: any }
   };
+
+  export interface Item {
+    [key: string]: any;
+  }
+
+  export type CalculateRowStyles = (item: Item) => {
+    backgroundColor?: string;
+    color?: string;
+    fontWeight?: string;
+  };
+
+  export type CalculateRowClasses = (item: Item) => string | undefined;
 </script>
 
 <script lang="ts">
@@ -28,10 +40,10 @@
   import type { ColumnBoolean, ColumnCheckBox, ColumnCustom, ColumnDate, ColumnIcon, ColumnNumber, ColumnString } from './columnTypes';
 
   let clazz: {
-    container?: string,
-    header?: string,
-    row?: string,
-    cell?: string
+    container?: string;
+    header?: string;
+    row?: string;
+    cell?: string;
   } = {};
 	export { clazz as class };
 
@@ -41,14 +53,17 @@
       sortDirection: string
     },
     'rowClick': {
-      item: { [key: string]: any }
+      item: Item
     }
   }>()
 
   export let headers: Header[] = [],
-    items: { [key: string]: any }[] = [],
+    items: Item[] = [],
     sortedBy: string | undefined = undefined,
-    sortDirection: 'asc' | 'desc' = 'asc';
+    sortDirection: "asc" | "desc" = "asc";
+
+  export let calculateRowStyles: CalculateRowStyles | undefined = undefined;
+  export let calculateRowClasses: CalculateRowClasses | undefined = undefined;
 
   function handleHeaderClick(header: Header) {
     if(!!sortedBy && header.value == sortedBy) {
@@ -74,11 +89,10 @@
   function formatDate(dateTime: DateTime, dateFormat: ColumnDate['params']): string  {
     return dateTime.setLocale(dateFormat.locale).toFormat(dateFormat.format)
   }
-
 </script>
 
 {#if !!items && Array.isArray(items)}
-  <div class="simple-table-container {clazz.container || ''}" >
+  <div class="simple-table-container {clazz.container || ''}">
     <table class="table">
       <thead class="thead {clazz.header || ''}">
         <tr>
@@ -121,9 +135,14 @@
       </thead>
       <tbody>
         {#each items as item, i}
-          <tr 
-            class="item-tr {clazz.row || ''}" 
+          {@const styles = !!calculateRowStyles ? calculateRowStyles(item) : {}}
+          {@const classes = !!calculateRowClasses ? calculateRowClasses(item) : ""}
+          <tr
+            class="item-tr {clazz.row || ''} {classes}"
             on:click={() => handleRowClick(item)}
+            style:background-color={styles.backgroundColor}
+            style:color={styles.color}
+            style:font-weight={styles.fontWeight}
           >
             {#each headers as header, j}
               <td class="{clazz.cell || ''}">
@@ -138,11 +157,11 @@
                 {:else if  header.type.key == "date"}
                   {formatDate(item[header.value], header.type.params)}
                 {:else if header.type.key == "icon"}
-                    <Icon 
-                      --icon-color={header.type.params?.color }  
-                      --icon-size={header.type.params?.size} 
-                      name={header.type.params?.name || ''}
-                    />
+                  <Icon
+                    --icon-color={header.type.params?.color}
+                    --icon-size={header.type.params?.size}
+                    name={header.type.params?.name || ""}
+                  />
                 {:else if header.type.key == 'string'}
                   {#if item[header.value] !== undefined && item[header.value] !== null}
                     {item[header.value]}

--- a/src/routes/docs/components/composed-components/PaginatedTable/+page.svelte
+++ b/src/routes/docs/components/composed-components/PaginatedTable/+page.svelte
@@ -2,7 +2,7 @@
   import ComponentSubtitle from "../../../ComponentSubtitle.svelte";
   import PropsViewer from "../../PropsViewer.svelte";
   import PaginatedTable from "$lib/components/composed/list/PaginatedTable.svelte";
-  import type {Filter} from "$lib/utils/filters/filters"
+  import type { Filter } from "$lib/utils/filters/filters";
   import type { Header } from "$lib/components/simple/lists/SimpleTable.svelte";
   import Icon from "$lib/components/simple/media/Icon.svelte";
   import type Builder from "$lib/utils/filters/builder";
@@ -13,28 +13,31 @@
         value: 'businessName',
         label: 'Business name',
         type: {
-          key:"string"
-        }
-      }, {
-        value: 'productName',
-        label: 'Product Name',
-        type: {
-          key:"string"
-        },
-        sortable: true,
-      }, {
-        value: 'progress',
-        label: 'Progress',
-        type: {
-          key:"string"
-        },
-      }, {
-        value: 'rating',
-        label: 'Rating',
-        type: {
-          key:"custom"
-        },
-        sortable: true,
+        key: "string",
+      },
+    },
+    {
+      value: "productName",
+      label: "Product Name",
+      type: {
+        key: "string",
+      },
+      sortable: true,
+    },
+    {
+      value: "progress",
+      label: "Progress",
+      type: {
+        key: "string",
+      },
+    },
+    {
+      value: "rating",
+      label: "Rating",
+      type: {
+        key: "custom",
+      },
+      sortable: true,
       }
     ]
 
@@ -98,6 +101,27 @@
     updateFunction(filterName, newValue, isValid)
   }
 
+  function calculateRowStyles(item: { [key: string]: any }): {
+    backgroundColor?: string;
+    color?: string;
+    fontWeight?: string;
+  } {
+    if (!!item.businessName && item.businessName == "GQ Creators") {
+      return {
+        backgroundColor: "rgba(var(--global-color-primary-300), 0.8)",
+        color: "#fff",
+        fontWeight: "900",
+      };
+    }
+    return {}
+  }
+
+  function calculateRowClasses(item: { [key: string]: any }): string | undefined {
+    if (!!item.businessName && item.businessName == "Popular My") {
+      return 'calculated-class'
+    }
+    return ''
+  }
 </script>
 
 <h1>PaginatedTable With Filter Panel</h1>
@@ -109,26 +133,30 @@
     headers={headers}
     items={[
       {
-        businessName: 'GQ Creators',
-        productName: 'Data Protection',
-        progress: '339 sold',
-        rating: 5
-      }, {
-        businessName: 'Dribblers Agency',
-        productName: 'Job Search',
-        progress: '212 sold',
-        rating: 4.5
-      }, {
-        businessName: 'Popular My',
-        productName: 'Financial Transactions',
-        progress: '94 sold',
-        rating: 4.2
+        businessName: "GQ Creators",
+        productName: "Data Protection",
+        progress: "339 sold",
+        rating: 5,
+      },
+      {
+        businessName: "Dribblers Agency",
+        productName: "Job Search",
+        progress: "212 sold",
+        rating: 4.5,
+      },
+      {
+        businessName: "Popular My",
+        productName: "Financial Transactions",
+        progress: "94 sold",
+        rating: 4.2,
       },
     ]}
     searchBarColumns={['businessName', 'productName']}
     totalElements={40}
     on:filtersChange={handleFiltersChange}
     editFilterMode="multi-edit"
+    {calculateRowStyles}
+    {calculateRowClasses}
   >
   <svelte:fragment slot="custom-filter" let:filter let:updateFunction>
     {#if !!filter}
@@ -184,5 +212,9 @@
     justify-content: center;
     gap: 10px;
     margin-bottom: 20px;
+  }
+
+  :global(.calculated-class) {
+    background-color: rgba(var(--global-color-contrast-200), 0.2);
   }
 </style>


### PR DESCRIPTION
Task collegata: [DUEDIL-184](https://app.clickup.com/t/18333660/DUEDIL-184)

Aggiungere due metodi calculateRowClasses e calculateRowStyles per apllicare stili a righe singole nel SimpleTable. Passare i metodi come props opzionali.

Ho inserito un esempio di utilizzo in .../PaginatedTable/+page.svelte.