### PR TITLE
fix document mouse up & resizer box-sizing

### DIFF
--- a/src/lib/components/simple/lists/SimpleTable.svelte
+++ b/src/lib/components/simple/lists/SimpleTable.svelte
@@ -74,20 +74,38 @@
   onMount(() => {
     if(resizableColumns) {
       for(const head of [...headers, { value: 'slot-append' }]) {
-        let th = document.getElementById(head.value) as HTMLElement
+        let th
+        if(head.value == 'slot-append') {
+          th = document.getElementsByClassName(head.value).item(0) as HTMLElement
+        } else {
+          th = document.getElementById(head.value) as HTMLElement
+        }
         if(!!th) {
-          let { paddingLeft, paddingRight } = getComputedStyle(th)
-          let widthWihtPadding: number
-          if(!!resizedColumnSizeWithPadding[head.value]) {
-            widthWihtPadding = resizedColumnSizeWithPadding[head.value]
+          let widthWihtPadding;
+          if (!!resizedColumnSizeWithPadding[head.value]) {
+            widthWihtPadding = resizedColumnSizeWithPadding[head.value];
           } else {
-            widthWihtPadding = th.getBoundingClientRect().width
-            resizedColumnSizeWithPadding[head.value] = widthWihtPadding
+            widthWihtPadding = th.getBoundingClientRect().width;
+            resizedColumnSizeWithPadding[head.value] = widthWihtPadding;
           }
-          let width = widthWihtPadding - parseFloat(paddingLeft) - parseFloat(paddingRight)
+        }
+      }
+
+      for(const head of [...headers, { value: 'slot-append' }]) {
+        let th
+        if(head.value == 'slot-append') {
+          th = document.getElementsByClassName(head.value).item(0) as HTMLElement
+        } else {
+          th = document.getElementById(head.value) as HTMLElement
+        }
+        if(!!th) {
+          let { paddingLeft, paddingRight } = getComputedStyle(th);
+          let width = resizedColumnSizeWithPadding[head.value] - parseFloat(paddingLeft) - parseFloat(paddingRight);
+          console.log(resizedColumnSizeWithPadding[head.value], paddingLeft, paddingRight, width)
           th.style.width = `${width}px`
         }
       }
+
       let table = document.getElementsByClassName('table')[0] as HTMLElement
       table.classList.add('resizable')
     }
@@ -233,7 +251,7 @@
             </th>
           {/each}
           {#if $$slots.rowActions || $$slots.append}
-            <th id="slot-append">
+            <th class="slot-append">
               <slot name="append" index={-1} items={undefined} />
             </th>
           {/if}
@@ -286,7 +304,7 @@
               </td>
             {/each}
             {#if $$slots.rowActions || $$slots.append}
-              <td class="{clazz.cell || ''}">
+              <td class="{clazz.cell || ''} append" style:width="fit-content">
                 <slot name="rowActions" index={i} {item} />
                 <slot name="append" index={i} {item} />
               </td>
@@ -299,6 +317,20 @@
 {/if}
 
 <style>
+
+  th.slot-append {
+    width: 1px;
+    min-width: unset;
+  }
+
+  .table.resizable .slot-append {
+    box-sizing: content-box;
+  }
+
+  .table.resizable td.append {
+    padding: 0;
+  }
+
   .simple-table-container.resizable {
     overflow-x: auto;
   }
@@ -475,6 +507,7 @@
     min-width: 100px;
     position: relative;
     user-select: none;
+    box-sizing: content-box;
   }
 
   td {

--- a/src/lib/components/simple/lists/SimpleTable.svelte
+++ b/src/lib/components/simple/lists/SimpleTable.svelte
@@ -155,7 +155,6 @@
 
       function mouseUpHandler(e: MouseEvent) {
         if(!!th) {
-          e.stopPropagation()
           resizing = false
           let { paddingLeft, paddingRight } = getComputedStyle(th)
           width = th.getBoundingClientRect().width - parseFloat(paddingLeft) - parseFloat(paddingRight)
@@ -316,6 +315,7 @@
     cursor: col-resize;
     background-clip: content-box;
     padding: 0px 5px 0px 5px;
+    box-sizing: content-box;
   }
 
   th:hover .resizer {

--- a/src/routes/docs/components/simple-components/SimpleTable/+page.svelte
+++ b/src/routes/docs/components/simple-components/SimpleTable/+page.svelte
@@ -136,6 +136,12 @@
           <Icon name="mdi-star" --icon-color="green"></Icon>
         {/if}
       </svelte:fragment>
+      <svelte:fragment slot="append" let:index>
+        {#if index == -1}
+          Append
+        {/if}
+      </svelte:fragment>
+      <svelte:fragment slot="rowActions">RowActions</svelte:fragment>
   </SimpleTable>
 </div>
 <h2>Props</h2>


### PR DESCRIPTION
- Per rendere le colonne resizable viene usato un eventListener mouseup sul document nel quale veniva stoppata la propagazione dell'evento andando di fatto a interferire con altri eventi mouseUp sul document.
- In alcuni casi il resizer della SimpleTable ereditava il box-sizing: border-box e di conseguenza la width del resizer veniva calcolata a 0. Ho specificato box-sizing: content-box per evitare il problema.