### PR TITLE
DUEDIL-974 add filters dropdown max height via css props

### DIFF
--- a/src/lib/components/composed/search/Filters.svelte
+++ b/src/lib/components/composed/search/Filters.svelte
@@ -681,6 +681,7 @@
         _boxShadow="rgb(var(--global-color-grey-900), .5) 0px 2px 4px"
         _height="fit-content"
         _minWidth="10vw"
+        _maxHeight="var(--one-edit-filters-menu-max-height, 100%)"
         _borderRadius="5px"
         anchor="bottom"
         openingId="select-filter"

--- a/src/routes/docs/components/composed-components/PaginatedTable/+page.svelte
+++ b/src/routes/docs/components/composed-components/PaginatedTable/+page.svelte
@@ -174,6 +174,7 @@
     showActiveFilters={true}
     {calculateRowStyles}
     {calculateRowClasses}
+    --one-edit-filters-menu-max-height="50vh"
   >
   <svelte:fragment slot="custom-filter" let:filter let:updateFunction>
     {#if !!filter}
@@ -214,12 +215,12 @@
     // }
   ]}
   styleProps={[
-    // {
-    //   name: '--button-max-width',
-    //   type: 'string',
-    //   default: 'undefined',
-    //   description: 'The max width of the outer element'
-    // }
+    {
+      name: '--one-edit-filters-menu-max-height',
+      type: 'string',
+      default: '100%',
+      description: 'The max height of the filters dropdown element when "one-edit" mode is active'
+    }
   ]}
 ></PropsViewer>
 <h2>Slots</h2>


### PR DESCRIPTION
Al momento quando la lista di filtri è troppo lunga e va in overflow, il componente inverte la direzione. 

Questo però fa in modo che nella PaginatedTable i filtri si aprano al contrario quando sono troppi. 
![image](https://github.com/user-attachments/assets/aebdc2cc-94cb-4635-96eb-2d1da5b4a44e)

Ho visto che il componente ha una prop _maxHeight che risolverebbe il problema, quindi la mia idea era passargi il valore via CSS (es: --one-edit-filters-menu-max-height), in modo che se esiste prende quel valore.