### PR TITLE
DUEDIL-974 add filters dropdown max height via css props v5

### DIFF
--- a/src/lib/components/composed/search/Filters.css
+++ b/src/lib/components/composed/search/Filters.css
@@ -1,6 +1,7 @@
 :root {
   --filters-button-cancel-default-background-color: transparent;
   --filters-button-cancel-default-color: rgb(var(--global-color-primary-400));
+  --one-edit-filters-default-menu-max-height: 100%;
   --filters-default-wrapper-width: auto;
   --filters-default-button-height: 28px;
 }

--- a/src/lib/components/composed/search/Filters.svelte
+++ b/src/lib/components/composed/search/Filters.svelte
@@ -717,6 +717,7 @@
           _boxShadow="rgb(var(--global-color-grey-900), .5) 0px 2px 4px"
           _height="fit-content"
           _minWidth="10vw"
+          _maxHeight="var(--one-edit-filters-menu-max-height, var(--one-edit-filters-default-menu-max-height))"
           _borderRadius="5px"
           anchor="bottom"
           openingId="select-filter"

--- a/src/routes/docs/components/composed-components/PaginatedTable/+page.svelte
+++ b/src/routes/docs/components/composed-components/PaginatedTable/+page.svelte
@@ -197,6 +197,7 @@
     showActiveFilters={true}
     {calculateRowStyles}
     {calculateRowClasses}
+    --one-edit-filters-menu-max-height="50vh"
   >
   {#snippet customFilterSnippet({ filter, mAndDown, updateFunction, })}
     {#if !!filter}
@@ -300,7 +301,14 @@
     },
     { name: "class", type: '{ simpleTable?: { container?: string, header?: string, row?: string, cell?: string } }', description: "Custom class mappings for inner components.", default: "{}" }
   ]}
-  styleProps={[]}
+  styleProps={[
+    {
+      name: '--one-edit-filters-menu-max-height',
+      type: 'string',
+      default: '100%',
+      description: 'The max height of the filters dropdown element when "one-edit" mode is active'
+    }
+  ]}
 ></PropsViewer>
 <h2>Slots</h2>
 <SlotsViewer


### PR DESCRIPTION


Al momento quando la lista di filtri è troppo lunga e va in overflow, il componente inverte la direzione.

Questo però fa in modo che nella PaginatedTable i filtri si aprano al contrario quando sono troppi.
image

Ho visto che il componente ha una prop _maxHeight che risolverebbe il problema, quindi la mia idea era passargi il valore via CSS (es: --one-edit-filters-menu-max-height), in modo che se esiste prende quel valore.
